### PR TITLE
Travis: sync config to main repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,6 @@
 language: rust
+rust: nightly
+
+before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get install -y libxinerama1 libxinerama-dev


### PR DESCRIPTION
Fixes build issues with travis since wtftw now depends on xinerama.
Also uses nightly compiler like the main repo to get consistent results.

This should fix Travis for #2 